### PR TITLE
Add Battle.net package recipe

### DIFF
--- a/battle.net/README.md
+++ b/battle.net/README.md
@@ -1,0 +1,29 @@
+# Battle.net chocolatey package
+
+### Pre-Requisites
+
+This package requires the `autohotkey` chocolatey package
+This package requires the `chocolatey-misc-helpers.extension` chocolatey package
+
+The updater requires a properly configured installation of [AU](https://github.com/majkinetor/au)
+
+### Quick start:
+
+This package makes a few assumptions:
+
+- Installs using the English language
+- Installs to the default path
+
+For a different language or path, the AutoHotKey install script would need to be updated for the new language or path
+
+### Notes:
+
+The Battle.net Launcher is built on demand when downloaded, so the checksum will be calculated on demand to be provided to `Install-ChocolateyPackage`
+
+My update_vars.ps1 are set to:
+
+```
+$Env:au_Push = 'true'     #Push to chocolatey
+$Env:au_PushUrl = 'https://chocolatey.zdl.io/chocolatey'
+$Env:au_GalleryPackageRootUrl = 'https://chocolatey.zdl.io/chocolatey/Packages'
+```

--- a/battle.net/battle.net.nuspec
+++ b/battle.net/battle.net.nuspec
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Read this before creating packages: https://docs.chocolatey.org/en-us/create/create-packages -->
+<!-- It is especially important to read the above link to understand additional requirements when publishing packages to the community feed aka dot org (https://community.chocolatey.org/packages). -->
+
+<!-- Test your packages in a test environment: https://github.com/chocolatey/chocolatey-test-environment -->
+
+<!--
+This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Reference. Chocolatey uses a special version of NuGet.Core that allows us to do more than was initially possible. As such there are certain things to be aware of:
+
+* the package xmlns schema url may cause issues with nuget.exe
+* Any of the following elements can ONLY be used by choco tools - projectSourceUrl, docsUrl, mailingListUrl, bugTrackerUrl, packageSourceUrl, provides, conflicts, replaces
+* nuget.exe can still install packages with those elements but they are ignored. Any authoring tools or commands will error on those elements
+-->
+
+<!-- You can embed software files directly into packages, as long as you are not bound by distribution rights. -->
+<!-- * If you are an organization making private packages, you probably have no issues here -->
+<!-- * If you are releasing to the community feed, you need to consider distribution rights. -->
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <!-- == PACKAGE SPECIFIC SECTION == -->
+    <!-- This section is about this package, although id and version have ties back to the software -->
+    <!-- id is lowercase and if you want a good separator for words, use '-', not '.'. Dots are only acceptable as suffixes for certain types of packages, e.g. .install, .portable, .extension, .template -->
+    <!-- If the software is cross-platform, attempt to use the same id as the debian/rpm package(s) if possible. -->
+    <id>battle.net</id>
+    <!-- version should MATCH as closely as possible with the underlying software -->
+    <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
+    <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
+    <version>1.18.5.3106</version>
+    <packageSourceUrl>https://github.com/Zoullx/chocolatey-packages/tree/master/battle.net</packageSourceUrl>
+    <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
+    <owners>Zoull</owners>
+    <!-- ============================== -->
+
+    <!-- == SOFTWARE SPECIFIC SECTION == -->
+    <!-- This section is about the software itself -->
+    <title>Battle.net</title>
+    <authors>Blizzard Entertainment</authors>
+    <!-- projectUrl is required for the community feed -->
+    <projectUrl>https://www.blizzard.com/en-us/apps/battle.net/desktop</projectUrl>
+    <!-- There are a number of CDN Services that can be used for hosting the Icon for a package. More information can be found here: https://docs.chocolatey.org/en-us/create/create-packages#package-icon-guidelines -->
+    <!-- Here is an example using Githack -->
+    <iconUrl>https://cdn.jsdelivr.net/gh/Zoullx/chocolatey-packages/icons/battlenet.png</iconUrl>
+    <copyright>© 2022 Blizzard Entertainment</copyright>
+    <!-- If there is a license Url available, it is required for the community feed -->
+    <!-- <licenseUrl>Software License Location __REMOVE_OR_FILL_OUT__</licenseUrl> -->
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <!--<projectSourceUrl>Software Source Location - is the software FOSS somewhere? Link to it with this</projectSourceUrl>-->
+    <!--<docsUrl>At what url are the software docs located?</docsUrl>-->
+    <!--<mailingListUrl></mailingListUrl>-->
+    <!--<bugTrackerUrl></bugTrackerUrl>-->
+    <tags>battle.net gaming launcher</tags>
+    <summary>Battle.net is a game launcher that puts all of your favorite Blizzard games all in one place</summary>
+    <description>
+# Get started now - for free
+
+Sling cards featuring legends of Warcraft lore, battle it out in an intergalactic arena, or wage war for supremacy of the stars. On Battle.net, you can dive into games like Hearthstone, StarCraft, and Heroes of the Storm for countless hours of free-to-play fun.
+
+You can also check out trial versions of many of our most popular games to discover new favorites before you buy.
+
+Hearthstone, StarCraft, Heroes of the Storm
+
+# Connect with your friends
+
+With customizable profiles, chats, groups, voice chat, and real-time status updates, Battle.net makes being social simple.
+
+Stay connected without staying tethered to your desk by downloading our Mobile App!
+
+# Shop for digital games and goodies
+
+Pick up the newest games and expansions, surprise your friends with digital gifts, or deck out your in-game characters with pets, mounts, and cosmetics. It only takes a few clicks in the shop.
+    </description>
+    <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
+    <!-- =============================== -->
+
+    <!-- Specifying dependencies and version ranges? https://docs.nuget.org/create/versioning#specifying-version-ranges-in-.nuspec-files -->
+    <dependencies>
+      <!-- <dependency id="" version="__MINIMUM_VERSION__" />
+      <dependency id="" version="[__EXACT_VERSION__]" />
+      <dependency id="" version="[_MIN_VERSION_INCLUSIVE, MAX_VERSION_INCLUSIVE]" />
+      <dependency id="" version="[_MIN_VERSION_INCLUSIVE, MAX_VERSION_EXCLUSIVE)" /> -->
+      <dependency id="autohotkey" />
+      <dependency id="chocolatey-misc-helpers.extension" />
+      <!-- <dependency id="chocolatey-core.extension" version="1.1.0" /> -->
+    </dependencies>
+    <!-- chocolatey-core.extension - https://community.chocolatey.org/packages/chocolatey-core.extension
+         - You want to use Get-UninstallRegistryKey on less than 0.9.10 (in chocolateyUninstall.ps1)
+         - You want to use Get-PackageParameters and on less than 0.11.0
+         - You want to take advantage of other functions in the core community maintainer's team extension package
+    -->
+
+    <!--<provides>NOT YET IMPLEMENTED</provides>-->
+    <!--<conflicts>NOT YET IMPLEMENTED</conflicts>-->
+    <!--<replaces>NOT YET IMPLEMENTED</replaces>-->
+  </metadata>
+  <files>
+    <!-- this section controls what actually gets packaged into the Chocolatey package -->
+    <file src="tools\**" target="tools" />
+    <!--Building from Linux? You may need this instead: <file src="tools/**" target="tools" />-->
+  </files>
+</package>

--- a/battle.net/tools/battle.net_install.ahk
+++ b/battle.net/tools/battle.net_install.ahk
@@ -1,0 +1,43 @@
+#NoEnv ; Recommended for performance and compatibility with future AutoHotkey releases.
+#NoTrayIcon
+#Warn ; Enable warnings to assist with detecting common errors.
+SendMode Input ; Recommended for new scripts due to its superior speed and reliability.
+SetTitleMatchMode, 1 ; A windows's title must start with the specified WinTitle to be a match.
+SetControlDelay 0
+SetWorkingDir %A_ScriptDir% ; Ensures a consistent starting directory.
+
+; Locale suppressed to be asked each time for language (enUS,frFR...)
+RegDelete, HKEY_CURRENT_USER\Software\Blizzard Entertainment\Launcher, Locale
+
+winTitle = ahk_class Blizzard Bootstrapper ahk_exe battle.netInstall.EXE
+
+; Select a Language
+; enGB zhCN zhTW deDE enSG esES esMX frFR itIT plPL ptBR ptPT ruRU
+WinWait, %winTitle%,, 15
+If WinExist(winTitle)
+{
+    ; English by default, unless otherwise stated
+    WinActivate
+    Send {Enter} ; Continue
+}
+
+; Download Window
+; Wait for the download to finish
+WinWait, %winTitle%,, 15
+If WinExist(winTitle)
+{
+    Sleep, 20000
+}
+
+; Choose install location
+; C:\Program Files (x86)\Battle.net (Default)
+; Also contains the option to stop Battle.net from starting on start up
+WinWait, %winTitle%,, 15
+If WinExist(winTitle)
+{
+    ; Proceed with defaults
+    WinActivate
+    Send {Enter} ; Continue
+}
+
+Exit

--- a/battle.net/tools/battle.net_uninstall.ahk
+++ b/battle.net/tools/battle.net_uninstall.ahk
@@ -1,0 +1,20 @@
+#NoEnv ; Recommended for performance and compatibility with future AutoHotkey releases.
+#NoTrayIcon
+#Warn ; Enable warnings to assist with detecting common errors.
+SendMode Input ; Recommended for new scripts due to its superior speed and reliability.
+SetTitleMatchMode, 1 ; A windows's title must start with the specified WinTitle to be a match.
+SetControlDelay 0
+SetWorkingDir %A_ScriptDir% ; Ensures a consistent starting directory.
+
+winTitle = ahk_class BlizzardUninstallWindowClass ahk_exe Blizzard Uninstaller.exe
+
+; Uninstall Battle.net
+WinWait, %winTitle%,, 15
+If WinExist(winTitle)
+{
+    WinActivate
+    Send {Tab} ; Switch from No, don't uninstall
+    Send {Enter} ; Yes, uninstall
+}
+
+Exit

--- a/battle.net/tools/chocolateyinstall.ps1
+++ b/battle.net/tools/chocolateyinstall.ps1
@@ -1,0 +1,26 @@
+$ErrorActionPreference = 'Stop';
+$toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$ahkExe       = 'AutoHotKey'
+$ahkFile      = "$toolsDir\battle.net_install.ahk"
+$url          = 'https://us.battle.net/download/getInstaller?os=win&installer=Battle.net-Setup.exe&id=undefined'
+$fileLocation = Join-Path $toolsDir 'Battle.net-Setup.exe'
+$checksumType = 'sha256'
+
+Invoke-WebRequest $url -OutFile $fileLocation -UseBasicParsing
+$checksum = (Get-FileHash $fileLocation -Algorithm $checksumType).Hash
+
+$packageArgs = @{
+  packageName   = $env:ChocolateyPackageName
+  unzipLocation = $toolsDir
+  fileType      = 'EXE'
+  file          = $fileLocation
+  softwareName  = 'Battle.net*'
+  checksum      = $checksum
+  checksumType  = $checksumType
+  silentArgs    = ""
+  validExitCodes= @(0, 3010, 1641)
+}
+
+Start-Process $ahkExe $ahkFile
+Install-ChocolateyPackage @packageArgs
+Start-WaitandStop "Battle.net"

--- a/battle.net/tools/chocolateyuninstall.ps1
+++ b/battle.net/tools/chocolateyuninstall.ps1
@@ -1,0 +1,16 @@
+$ErrorActionPreference = 'Stop';
+$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$ahkExe     = 'AutoHotKey'
+$ahkFile    = "$toolsDir\battle.net_uninstall.ahk"
+
+$packageArgs = @{
+  packageName   = $env:ChocolateyPackageName
+  softwareName  = 'Battle.net*'
+  fileType      = 'EXE'
+  silentArgs    = '--lang=enUS --uid=battle.net --displayname="Battle.net"'
+  validExitCodes= @(0, 3010, 1605, 1614, 1641)
+  file          = 'C:\ProgramData\Battle.net\Agent\Blizzard Uninstaller.exe'
+}
+
+Start-Process $ahkExe $ahkFile
+Uninstall-ChocolateyPackage @packageArgs

--- a/battle.net/update.ps1
+++ b/battle.net/update.ps1
@@ -1,0 +1,33 @@
+#Requires -Version 5.0
+#Requires -Modules AU
+[cmdletbinding()]
+param (
+  [switch]$Force
+)
+
+$ErrorActionPreference = 'Stop'
+
+$downloadUrl = 'https://us.battle.net/download/getInstaller?os=win&installer=Battle.net-Setup.exe&id=undefined'
+
+function Get-RemoteFileVersion( [string] $Url ) {
+  $fn = [System.IO.Path]::GetTempFileName()
+  Invoke-WebRequest $Url -Outfile $fn -UseBasicParsing
+  $res = (Get-ItemProperty $fn).VersionInfo.FileVersion
+  Remove-Item $fn -ea ignore
+  return $res
+}
+
+function global:au_GetLatest {
+  $version = Get-RemoteFileVersion -Url $downloadUrl
+
+  return @{
+    Version = $version
+    URL32   = $downloadUrl
+  }
+}
+
+# run the update only if this script is not sourced by the virtual package
+if ($MyInvocation.InvocationName -ne '.') {
+  [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
+  Update-Package -NoCheckUrl -NoCheckChocoVersion -NoReadme -ChecksumFor none -Force:$Force
+}


### PR DESCRIPTION
The updates to the Battle.net chocolatey package can't be pushed to the public feed because the executable is built on demand and therefore has a different checksum every time it's downloaded. But I would still like to submit the updates somewhere so that the community can access a working Battle.net chocolatey package.